### PR TITLE
Fix hunter killer lookup in job listener

### DIFF
--- a/src/main/java/net/devvoxel/jobs/listener/JobActionListener.java
+++ b/src/main/java/net/devvoxel/jobs/listener/JobActionListener.java
@@ -10,7 +10,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.Tag;
-import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -107,7 +107,7 @@ public class JobActionListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityKill(EntityDeathEvent event) {
-        Entity entity = event.getEntity();
+        LivingEntity entity = event.getEntity();
         Player killer = entity.getKiller();
         if (killer == null) {
             return;


### PR DESCRIPTION
## Summary
- import `LivingEntity` and use it to access the killer in the hunter feedback listener

## Testing
- ⚠️ `mvn -q -e -DskipTests compile` *(fails: unable to download maven-resources-plugin due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_69061727b310832e8db38ca12b0cf046