### PR TITLE
Add JitPack repository for Vault API dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- add the JitPack repository to resolve the VaultAPI dependency during builds

## Testing
- `mvn -q -e package` *(fails: Maven Central returned HTTP 403 for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_69062877e36c832e9ab2f575f0428b31